### PR TITLE
Add C++ compatibility

### DIFF
--- a/port/ioLibrary_Driver/inc/w5x00_gpio_irq.h
+++ b/port/ioLibrary_Driver/inc/w5x00_gpio_irq.h
@@ -7,6 +7,10 @@
 #ifndef _W5X00_GPIO_IRQ_H_
 #define _W5X00_GPIO_IRQ_H_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * ----------------------------------------------------------------------------------------------------
  * Macros
@@ -40,5 +44,9 @@ void wizchip_gpio_interrupt_initialize(uint8_t socket, void (*callback)(void));
  *  \param events Which events caused this interrupt. See \ref gpio_set_irq_enabled for details.
  */
 static void wizchip_gpio_interrupt_callback(uint gpio, uint32_t events);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _W5X00_GPIO_IRQ_H_ */

--- a/port/ioLibrary_Driver/inc/w5x00_spi.h
+++ b/port/ioLibrary_Driver/inc/w5x00_spi.h
@@ -7,6 +7,10 @@
 #ifndef _W5X00_SPI_H_
 #define _W5X00_SPI_H_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * ----------------------------------------------------------------------------------------------------
  * Macros
@@ -181,5 +185,9 @@ void network_initialize(wiz_NetInfo net_info);
  *  \param net_info network information.
  */
 void print_network_information(wiz_NetInfo net_info);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _W5X00_SPI_H_ */

--- a/port/timer/timer.h
+++ b/port/timer/timer.h
@@ -7,6 +7,10 @@
 #ifndef _TIMER_H_
 #define _TIMER_H_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * ----------------------------------------------------------------------------------------------------
  * Macros
@@ -48,5 +52,9 @@ bool wizchip_1ms_timer_callback(struct repeating_timer *t);
  *  \param ms the number of milliseconds to sleep
  */
 void wizchip_delay_ms(uint32_t ms);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _TIMER_H_ */


### PR DESCRIPTION
The headers of the port directory are missing the ```extern "C"```.   
It is required for use in a C++ environment.